### PR TITLE
ALIST-TO-JSON: More proper way to process alist using LOOP.

### DIFF
--- a/src/encode.lisp
+++ b/src/encode.lisp
@@ -165,8 +165,8 @@
 (defun alist-to-json (list)
   (declare (optimize (speed 3) (safety 0) (debug 0)))
   (with-object
-    (loop for (item rest) on list
-          do (write-key-value (car item) (cdr item)))))
+    (loop for (key . value) in list
+          do (write-key-value key value))))
 
 (declaim (inline plist-to-json))
 (defun plist-to-json (list)


### PR DESCRIPTION
Hello, Jonathan.
remove unused var(rest) and more proper way to process alist using LOOP.
