### PR TITLE
Quick fix for ABCL support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - LISP=sbcl-bin COVERALLS=true
     - LISP=sbcl/1.1.14
     - LISP=ccl-bin
-    # - LISP=abcl
+    - LISP=abcl
     - LISP=clisp
     # - LISP=ecl
     # - LISP=allegro

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -186,7 +186,8 @@
                          (progn
                            (advance* 4)
                            (unless (and (char= (current) #\\)
-                                        (char= (and (advance*) (current)) #\u))
+                                        (advance*)
+                                        (char= (current) #\u))
                              (error '<jonathan-without-tail-surrogate-error>))
                            (advance*)
                            (let ((tail-code


### PR DESCRIPTION
As `advance*` may return `NIL` and `char=` will raise a different error,
basically this change should be welcomed even for other implementations.
