### PR TITLE
Prevent from ASDF read error when the character encoding is ASCII

### DIFF
--- a/jonathan.asd
+++ b/jonathan.asd
@@ -29,7 +29,9 @@
                              #p"README.md"
                              (or *load-pathname* *compile-file-pathname*))
                             :if-does-not-exist nil
-                            :direction :input)
+                            :direction :input
+                            :element-type #+lispworks :default #-lispworks 'character
+                            :external-format #+clisp charset:utf-8 #-clisp :utf-8)
       (when stream
         (let ((seq (make-array (file-length stream)
                                :element-type 'character


### PR DESCRIPTION
README.md containing UTF-8 characters is read in jonathan.asd and it causes read error while loading:

```
Error while trying to load definition for system jonathan from pathname
/srv/www/fukabot/bundle-libs/software/jonathan-20151218-git/jonathan.asd:
   READ error during LOAD:

     :ASCII stream decoding error on
     #<SB-SYS:FD-STREAM
       for "file /srv/www/fukabot/bundle-libs/software/jonathan-20151218-git/README.md"
       {100D8B0353}>:

       the octet sequence #(227) cannot be decoded.

     (in form starting at line: 6, column: 0, position: 95)
```
