### PR TITLE
Add method for simple-string

### DIFF
--- a/src/encode.lisp
+++ b/src/encode.lisp
@@ -207,8 +207,11 @@
 "Write obj as JSON string."
 (defgeneric %to-json (obj))
 
-(defmethod %to-json ((string string))
+(defmethod %to-json ((string simple-string))
   (string-to-json string))
+
+(defmethod %to-json ((string string))
+  (string-to-json (princ-to-string string)))
 
 (defmethod %to-json ((number number))
   (%write-string (princ-to-string number)))

--- a/t/encode.lisp
+++ b/t/encode.lisp
@@ -72,6 +72,12 @@
 
 (is (to-json "Rudolph")
     "\"Rudolph\""
+    "with simple-string.")
+
+(is (to-json (let* ((simple-string "Rudolph")
+                    (not-so-simple-string (make-array 7 :element-type 'character :displaced-to simple-string :displaced-index-offset 0)))
+               not-so-simple-string))
+    "\"Rudolph\""
     "with string.")
 
 (is (to-json (format nil "Rudo~alph" #\Newline))


### PR DESCRIPTION
Fixes Rudolph-Miller/jonathan#40 by adding a method on `simple-string`
and changing `string`'s method to use a slower way, but not error.
