### PR TITLE
Allow to parse double-float in JSON.

### DIFF
--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -269,8 +269,15 @@
                                    (block nil
                                      (let ((rest-start (the fixnum (pos))))
                                        (bind (rest-num-str (skip-while integer-char-p))
-                                         (let ((rest-num (the fixnum (parse-integer rest-num-str))))
-                                           (return (+ num  (float (/ rest-num (the fixnum (expt 10 (- (pos) rest-start)))))))))))))
+                                         (let* ((rest-num (the fixnum (parse-integer rest-num-str)))
+                                                (digits-len (the fixnum (- (pos) rest-start)))
+                                                (bits-len (the fixnum (+ digits-len (length num-str)))))
+                                           (return
+                                             (+ num
+                                                (coerce (/ rest-num (expt 10 digits-len))
+                                                        (if (< 8 bits-len)
+                                                            'double-float
+                                                            'single-float))))))))))
                            (when (with-allowed-last-character ()
                                    (skip? #\e #\E))
                              (setq num

--- a/t/decode.lisp
+++ b/t/decode.lisp
@@ -12,7 +12,7 @@
 
 (diag "jonathan-test.decode")
 
-(plan 31)
+(plan 32)
 
 (defvar *upper-exponent* (gensym "upper"))
 (defvar *lower-exponent* (gensym "lower"))
@@ -304,5 +304,16 @@
 
   (ok (not (foldable-keywords-to-read-p 'x))
       "with variable."))
+
+(subtest "double-float"
+  (is (parse "35.65910807942215")
+      35.65910807942215d0
+      "Can parse double-float")
+  (is (parse "139.70372892916203")
+      139.70372892916203d0
+      "Can parse double-float")
+  (is (parse "35.659108")
+      35.659108
+      "Can parse single-float"))
 
 (finalize)


### PR DESCRIPTION
`float` in Common Lisp usually means `single-float` and it can represent a number which has 8 digits at most.
However, JSON's float can be a double-float:

``` common-lisp
(jojo:parse "35.65910807942215")
;=> 35.659107
```

This patch allows `jojo:parse` to parse double-floats too:

``` common-lisp
(jojo:parse "35.65910807942215")
;=> 35.65910807942215d0

(jojo:parse "35.659108")
;=> 35.659108
```
