### PR TITLE
Unicode surrogate parsing was fixed.

### DIFF
--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -178,6 +178,9 @@
                                                            unicode-chars)))
                        (advance*))))
                  (read-unicode-escape-sequence ()
+                   "Returns a pair like (char . is-surrogate-p) where
+                    is-surrogate-p is `t' if char is a surrogate unicode symbol and
+                    `nil' otherwise."
                    (advance*)
                    (let ((char-code (parse-integer (subseq string (pos) (+ (pos) 4))
                                                    :radix 16)))
@@ -230,7 +233,7 @@
                                       (#\u (if unescape-unicode-escape-sequence
                                                (let ((pair (pop unicode-chars)))
                                                  (if (cdr pair)
-                                                     (incf index 11)
+                                                     (incf index 10)
                                                      (incf index 4))
                                                  (car pair))
                                                #\u))

--- a/t/decode.lisp
+++ b/t/decode.lisp
@@ -284,10 +284,15 @@
     (is (parse "\"\\u30b8\\u30e7\\u30ca\\u30b5\\u30f3\"")
         "ジョナサン"
         "without surrogate pair.")
-    #+(or :sbcl :clisp)
+    #+(or :sbcl :clisp :ccl)
     (is (parse "\"\\uD840\\uDC0B\"")
         "𠀋"
-        "with surrogate pair."))
+        "with surrogate pair.")
+    (is (parse "\"\\uD83D\\uDE3E\\uD83D\\uDD2A\"")
+        (concatenate 'string
+                     (parse "\"\\uD83D\\uDE3E\"")
+                     (parse "\"\\uD83D\\uDD2A\""))
+        "surrogate pairs should be parsed equally when they follow together and separate from each other."))
 
   (subtest "NIL"
     (is (parse "\"\\u30b8\\u30e7\\u30ca\\u30b5\\u30f3\""


### PR DESCRIPTION
Previously, jonathan considered the length of escaped surrogate pair is 11, but actually it is 10.
Because of this error, jonathan eat the character followed the surrogate pair or raised an error if
there is another surrogate pair goes right after the first one.

This pull fixes issue #52 
Also, it includes pull #37