### PR TITLE
Allow #\Return as whitespace in JSON

### DIFF
--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -75,7 +75,7 @@
                                                 :object string))
                                     `(error '<jonathan-unexpected-eof-error> :object string)))))))
                  (skip-spaces ()
-                   `(skip* #\Space #\Newline #\Tab))
+                   `(skip* #\Space #\Newline #\Tab #\Return))
                  (with-skip-spaces (&body body)
                    `(progn
                       (skip-spaces)


### PR DESCRIPTION
According to section 2 of RFC 4627, carriage return is one of the four allowed whitespace characters. However, it was missing from Jonathan's decoder.